### PR TITLE
fix playerarrow scale not applying on world map open

### DIFF
--- a/Mapster.lua
+++ b/Mapster.lua
@@ -242,6 +242,7 @@ function Mapster:WorldMapFrame_SynchronizeDisplayState()
 	if not WorldMapFrame:IsMaximized() then
 		self:SetPosition()
 	end
+	self:SetArrow()
 end
 
 function Mapster:HelpPlate_Show(plate, frame)


### PR DESCRIPTION
Noticed lately (since Midnight pre-patch maybe?) that my player arrow on the world map was huge every time I open the map.  When going into options it showed scale set to 50%, but moving the slider up and back down would show it wasn't actually at 50% to start and would then size it down properly... until you close and re-open the map and then it's huge again.  Apparently when Blizzard opens the map they call SynchronizePinSizes themselves which sets it to the default size, then SynchronizeDisplayState only sets scale and position... since we're already hooking into the map WorldMapFrame_OnShow and WorldMapFrame_SynchronizeDisplayState, I found adding a call to `self:SetArrow()` to either method seems to resolve it in my own testing, but since we're doing scale and position in the latter, I added it there for this PR.